### PR TITLE
[Bug Fix] use regexp

### DIFF
--- a/controllers/users.js
+++ b/controllers/users.js
@@ -3,8 +3,11 @@ const fetch = require("node-fetch");
 
 module.exports.getLogin = async (req, res) => {
   const baseUrl = "https://github.com/login/oauth/authorize";
+  const isDeployed = process.env.NODE_ENV === "production";
   const config = {
-    client_id: process.env.GH_CLIENTID,
+    client_id: isDeployed
+      ? process.env.GH_CLIENTID_PROD
+      : process.env.GH_CLIENTID_DEV,
     scope: "read:user user:email",
   };
   const params = new URLSearchParams(config).toString();
@@ -14,9 +17,14 @@ module.exports.getLogin = async (req, res) => {
 module.exports.postLogin = async (req, res) => {
   const baseUrl = "https://github.com/login/oauth/access_token";
   const { code } = req.query;
+  const isDeployed = process.env.NODE_ENV === "production";
   const config = {
-    client_id: process.env.GH_CLIENTID,
-    client_secret: process.env.GH_SECRET,
+    client_id: isDeployed
+      ? process.env.GH_CLIENTID_PROD
+      : process.env.GH_CLIENTID_DEV,
+    client_secret: isDeployed
+      ? process.env.GH_SECRET_PROD
+      : process.env.GH_SECRET_DEV,
     code,
   };
   const params = new URLSearchParams(config).toString();

--- a/src/views/index.pug
+++ b/src/views/index.pug
@@ -6,13 +6,11 @@ block content
                 div.card
                     div.row.g-0
                         div.col-3.d-flex.align-items-center.justify-content-center.px-2#thumbnail
-                            img(
-                                src=`${post.thumbnail.thumbnail}`
-                            ).rounded-start.rounded-end
+                            img(src=`${post.thumbnail.thumbnail}`).rounded-start.rounded-end
                         div.col-9
                             div.card-body
                                 h2.card-title #{post.title}
-                                p.card-text !{post.content.slice(0, 20)}
+                                p.card-text !{post.content.replace(/<[^>]+>/g, '').slice(0, 100)}...
                                 div.d-flex.justify-content-between
                                     span.card-text 
                                         small.text-muted 작성일: #{post.postedAt.toISOString().slice(0, 10)}


### PR DESCRIPTION
## ❔ 이슈 내용
### 4번째 포스팅 후 카드 템플릿 내 비정상적인 h2 태그 삽입
처리 결과
![image](https://user-images.githubusercontent.com/109511569/196035445-c33f2248-9701-4be4-bd26-047212d28505.png)
## ❗ 처리 방안 이행 여부
### pug 템플릿 엔진으로 전환 후에도 동일한 문제 지속됨.
### 확인 결과, 깃허브 레포 복사/붙여넣기 및 써머노트 작성 과정에서
### 기존 로직(.slice(0, 20))으로는 본문 내용이 포함되지 않음을 확인함.
### ➡ 정규표현식(.replace(/<[^>]+>/g, ''))을 통해 태그 삭제 후 컨텐츠를 이어붙여 처리 ✔
## 📜 체크리스트
### ✅ 태그 삽입 현상의 원인 파악 ✔
### ✅ 카드 템플릿 외 비슷한 현상의 버그 발생 가능성 파악(XSS 관련 작업 필요) ✔
### ✅ 로컬 환경 테스트를 위한 Github 로그인 환경 및 dotenv 분리 ✔
## 💣 데드라인
### `22.10.19 ➡ `22.10.16 처리 完 ✔
## 🎉 기대 효과
### 포스트 미리보기 템플릿 렌더링 정상화 ✔
## Issue Detected || Next Step
### ✅ 미리보기를 위해 포스팅 본문 전체를 정규표현식으로 처리하는 부분에 대한 처리 로직 개선 필요